### PR TITLE
add :root_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Dragonfly.app.configure do
   datastore :google,
             project: 'project-id-here',
             bucket: 'bucket-name-here',
-            keyfile: 'path/to/your/key/file.json'
+            keyfile: 'path/to/your/key/file.json',
+            root_path: 'root/path'
 end
 ```
 
@@ -50,4 +51,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/dragonfly/google_data_store.rb
+++ b/lib/dragonfly/google_data_store.rb
@@ -25,20 +25,22 @@ module Dragonfly
 
     def read(uid)
       file = bucket.file full_path(uid)
+
+      metadata = file.metadata
+      metadata['name'] ||= File.basename(file.name)
+
       content = file.download
       content.rewind
-      [
-        content.read,
-        file.metadata,
-      ]
-    rescue
+
+      [content.read, metadata]
+    rescue StandardError
       nil
     end
 
     def destroy(uid)
       file = bucket.file full_path(uid)
       file.delete
-    rescue
+    rescue StandardError
       nil
     end
 

--- a/lib/dragonfly/google_data_store.rb
+++ b/lib/dragonfly/google_data_store.rb
@@ -26,7 +26,7 @@ module Dragonfly
     def read(uid)
       file = bucket.file full_path(uid)
 
-      metadata = file.metadata
+      metadata = file.metadata.dup
       metadata['name'] ||= File.basename(file.name)
 
       content = file.download

--- a/lib/dragonfly/google_data_store.rb
+++ b/lib/dragonfly/google_data_store.rb
@@ -18,7 +18,12 @@ module Dragonfly
 
       uid = opts[:path] || Dragonfly::GoogleDataStore.generate_uid
 
-      bucket.create_file object.tempfile.path, full_path(uid), metadata: object.meta
+      bucket.create_file(
+        object.tempfile.path,
+        full_path(uid),
+        metadata: object.meta,
+        content_type: object.mime_type
+      )
 
       uid
     end


### PR DESCRIPTION
Adds `:root_path` option that allows to specify a subfolder in a bucket, where files should be stored.

Follows the API of [dragonfly-s3_data_store](https://github.com/markevans/dragonfly-s3_data_store).